### PR TITLE
No reentrant ckpt

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -38,6 +38,9 @@ local_dirs:
 #   is recommended, because they are slow
 sample_during_eval: true
 
+# how many model samples to generate during evaluation
+n_eval_model_samples: 16
+
 # whether to eval at the very beginning of training
 do_first_eval: true
 

--- a/config/model/gpt2-large.yaml
+++ b/config/model/gpt2-large.yaml
@@ -1,0 +1,8 @@
+name_or_path: gpt2-large
+tokenizer_name_or_path: null
+archive: null
+block_name: GPT2Block
+
+policy_dtype: float32
+fsdp_policy_mp: null
+reference_dtype: float16

--- a/config/model/gpt2-xl.yaml
+++ b/config/model/gpt2-xl.yaml
@@ -1,0 +1,8 @@
+name_or_path: gpt2-xl
+tokenizer_name_or_path: null
+archive: null
+block_name: GPT2Block
+
+policy_dtype: float32
+fsdp_policy_mp: null
+reference_dtype: float16

--- a/trainers.py
+++ b/trainers.py
@@ -276,7 +276,7 @@ class BasicTrainer(object):
                     if self.config.loss.name == 'dpo':
                         reference_text_table = wandb.Table(columns=["step", "prompt", "sample"])
 
-                for eval_batch in (tqdm.tqdm(self.eval_batches) if self.rank == 0 else self.eval_batches):
+                for eval_batch in (tqdm.tqdm(self.eval_batches, desc='Computing eval metrics') if self.rank == 0 else self.eval_batches):
                     local_eval_batch = slice_and_move_batch_for_device(eval_batch, self.rank, self.world_size, self.rank)
                     with torch.no_grad():
                         _, eval_metrics = self.get_batch_metrics(local_eval_batch, self.config.loss, train=False)
@@ -284,7 +284,11 @@ class BasicTrainer(object):
                     for k, v in eval_metrics.items():
                         all_eval_metrics[k].extend(v)
 
-                    if self.config.sample_during_eval:
+                if self.config.sample_during_eval:
+                    n_sample_batches = self.config.n_eval_model_samples // self.config.eval_batch_size
+                    sample_batches = self.eval_batches[:n_sample_batches]
+                    for eval_batch in (tqdm.tqdm(sample_batches, desc='Generating samples...') if self.rank == 0 else sample_batches):
+                        local_eval_batch = slice_and_move_batch_for_device(eval_batch, self.rank, self.world_size, self.rank)
                         if 'FSDP' in self.config.trainer:
                             with FSDP.summon_full_params(self.policy, writeback=False, recurse=False):
                                 policy_samples, reference_samples = self.get_batch_samples(local_eval_batch)


### PR DESCRIPTION
Merges the fix to activation checkpointing warnings shared in https://github.com/eric-mitchell/direct-preference-optimization/issues/9

Also includes minor config changes to decouple the number of examples used to compute eval metrics and the number of eval samples _generated_ by the model.